### PR TITLE
Fix NTlite presets + optimizations

### DIFF
--- a/ntlite presets/gyrOS 10 1909.xml
+++ b/ntlite presets/gyrOS 10 1909.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Preset isAutoSaved="true" xmlns="urn:schemas-nliteos-com:pn.v1">
 	<Date>04/19/2023 11:24:51</Date>
 	<AppInfo>
@@ -1474,12 +1474,12 @@
 			<Task>imageFormatWim</Task>
 			<Task>components_boot.wim_02_2_64</Task>
 		</ImageTasks>
-		<AutoIsoFile>NTLite.iso</AutoIsoFile>
+		<AutoIsoFile>gyrOS-1909.iso</AutoIsoFile>
 		<AutoIsoLabel>gyrOS</AutoIsoLabel>
 		<AutoSplitSize>4000</AutoSplitSize>
 		<CleanHotfixedLeftovers>3</CleanHotfixedLeftovers>
-		<OptimizeAppX>false</OptimizeAppX>
-		<ReuseDriverCache>false</ReuseDriverCache>
+		<OptimizeAppX>true</OptimizeAppX>
+		<ReuseDriverCache>true</ReuseDriverCache>
 	</ApplyOptions>
 	<Execution>
 		<Remove></Remove>

--- a/ntlite presets/gyrOS 10 22H2 FACEIT.xml
+++ b/ntlite presets/gyrOS 10 22H2 FACEIT.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Preset isAutoSaved="true" xmlns="urn:schemas-nliteos-com:pn.v1">
 	<Date>03/29/2023 22:29:34</Date>
 	<AppInfo>
@@ -1390,12 +1390,12 @@
 			<Task>imageFormatWim</Task>
 			<Task>components_boot.wim_02_2_64</Task>
 		</ImageTasks>
-		<AutoIsoFile>C:\Users\an0n\Desktop\gyrOS 22H2.iso</AutoIsoFile>
+		<AutoIsoFile>gyrOS-22h2.iso</AutoIsoFile>
 		<AutoIsoLabel>gyrOS</AutoIsoLabel>
 		<AutoSplitSize>4000</AutoSplitSize>
 		<CleanHotfixedLeftovers>3</CleanHotfixedLeftovers>
-		<OptimizeAppX>false</OptimizeAppX>
-		<ReuseDriverCache>false</ReuseDriverCache>
+		<OptimizeAppX>true</OptimizeAppX>
+		<ReuseDriverCache>true</ReuseDriverCache>
 	</ApplyOptions>
 	<Execution>
 		<Remove></Remove>

--- a/ntlite presets/gyrOS 10 22H2.xml
+++ b/ntlite presets/gyrOS 10 22H2.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Preset isAutoSaved="true" xmlns="urn:schemas-nliteos-com:pn.v1">
 	<Date>04/18/2023 19:59:51</Date>
 	<AppInfo>
@@ -1433,12 +1433,12 @@
 			<Task>imageFormatWim</Task>
 			<Task>components_boot.wim_02_2_64</Task>
 		</ImageTasks>
-		<AutoIsoFile>NTLite.iso</AutoIsoFile>
+		<AutoIsoFile>gyrOS-22h2.iso</AutoIsoFile>
 		<AutoIsoLabel>gyrOS</AutoIsoLabel>
 		<AutoSplitSize>4000</AutoSplitSize>
 		<CleanHotfixedLeftovers>3</CleanHotfixedLeftovers>
-		<OptimizeAppX>false</OptimizeAppX>
-		<ReuseDriverCache>false</ReuseDriverCache>
+		<OptimizeAppX>true</OptimizeAppX>
+		<ReuseDriverCache>true</ReuseDriverCache>
 	</ApplyOptions>
 	<Execution>
 		<Remove></Remove>

--- a/ntlite presets/gyrOS 11 22H2.xml
+++ b/ntlite presets/gyrOS 11 22H2.xml
@@ -1437,12 +1437,12 @@
 			<Task>deledition_boot.wim_01_9_64</Task>
 			<Task>imageFormatWim</Task>
 		</ImageTasks>
-		<AutoIsoFile>NTLite.iso</AutoIsoFile>
+		<AutoIsoFile>gyrOS-11.iso</AutoIsoFile>
 		<AutoIsoLabel>gyrOS 11</AutoIsoLabel>
 		<AutoSplitSize>4000</AutoSplitSize>
 		<CleanHotfixedLeftovers>3</CleanHotfixedLeftovers>
-		<OptimizeAppX>false</OptimizeAppX>
-		<ReuseDriverCache>false</ReuseDriverCache>
+		<OptimizeAppX>true</OptimizeAppX>
+		<ReuseDriverCache>true</ReuseDriverCache>
 	</ApplyOptions>
 	<Execution>
 		<Remove></Remove>


### PR DESCRIPTION
Changes made to the presets:
```
- All presets had a invalid symbol at the start, making the preset corrupt -> fixed
- Turned on optimizations e.g re-use driver cache, this makes the ISO a bit smaller, same for optimizing appx packages except doing that makes appx pkgs run faster
- Made the placeholder be named in this format: "gyrOS-<build>.iso" 
```