### PR TITLE
Timer Resolution

### DIFF
--- a/source/gyrOS_22H2.bat
+++ b/source/gyrOS_22H2.bat
@@ -1514,6 +1514,9 @@ reg add "HKLM\SYSTEM\CurrentControlSet\Control\Class\{71a27cdd-812a-11d0-bec7-08
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:: Timer Resolution
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\kernel" /v "GlobalTimerResolutionRequests" /t "REG_DWORD" /d "1" /f > nul 2> nul
+
 :: Fix Folder View Settings
 reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "NoSaveSettings" /t REG_SZ /d "0" /f > nul 2> nul
 reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "NoSaveSettings" /t REG_SZ /d "0" /f > nul 2> nul

--- a/source/gyrOS_FACEIT.bat
+++ b/source/gyrOS_FACEIT.bat
@@ -1493,6 +1493,9 @@ reg add "HKLM\SYSTEM\CurrentControlSet\Control\Class\{71a27cdd-812a-11d0-bec7-08
 
 :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
+:: Timer Resolution
+reg add "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\kernel" /v "GlobalTimerResolutionRequests" /t "REG_DWORD" /d "1" /f > nul 2> nul
+
 :: Fix Folder View Settings
 reg add "HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "NoSaveSettings" /t REG_SZ /d "0" /f > nul 2> nul
 reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\Explorer" /v "NoSaveSettings" /t REG_SZ /d "0" /f > nul 2> nul


### PR DESCRIPTION
Since timerres has been affected since 2004 https://randomascii.wordpress.com/2020/10/04/windows-timer-resolution-the-great-rule-change/ applied the same tweaks to 22H2 + Faceit.